### PR TITLE
interfaces: fix error in build for android pie

### DIFF
--- a/wifi/supplicant/1.0/Android.mk
+++ b/wifi/supplicant/1.0/Android.mk
@@ -91,10 +91,15 @@ intermediates := $(call local-generated-sources-dir, COMMON)
 
 HIDL := $(HOST_OUT_EXECUTABLES)/hidl-gen$(HOST_EXECUTABLE_SUFFIX)
 
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
+LOCAL_STATIC_JAVA_LIBRARIES := \
+    android.hardware.wifi.supplicant-V1.0-java \
+    android.hidl.base-V1.0-java
+else
 LOCAL_STATIC_JAVA_LIBRARIES := \
     android.hardware.wifi.supplicant-V1.0-java-static \
-    android.hidl.base-V1.0-java-static \
-
+    android.hidl.base-V1.0-java-static
+endif
 
 #
 # Build ISupplicantVendorStaIface.hal

--- a/wifi/supplicant/1.1/Android.mk
+++ b/wifi/supplicant/1.1/Android.mk
@@ -110,11 +110,17 @@ intermediates := $(call local-generated-sources-dir, COMMON)
 
 HIDL := $(HOST_OUT_EXECUTABLES)/hidl-gen$(HOST_EXECUTABLE_SUFFIX)
 
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
+LOCAL_STATIC_JAVA_LIBRARIES := \
+    android.hardware.wifi.supplicant-V1.0-java \
+    android.hidl.base-V1.0-java \
+    vendor.qti.hardware.wifi.supplicant-V1.0-java
+else
 LOCAL_STATIC_JAVA_LIBRARIES := \
     android.hardware.wifi.supplicant-V1.0-java-static \
     android.hidl.base-V1.0-java-static \
-    vendor.qti.hardware.wifi.supplicant-V1.0-java-static \
-
+    vendor.qti.hardware.wifi.supplicant-V1.0-java-static
+endif
 
 #
 # Build ISupplicantVendorP2PIface.hal


### PR DESCRIPTION
vendor/qcom/opensource/interfaces/wifi/supplicant/1.0/Android.mk: error: vendor.qti.hardware.wifi.supplicant-V1.0-java-static (JAVA_LIBRARIES android-arm64) missing android.hardware.wifi.supplicant-V1.0-java-static (JAVA_LIBRARIES android-arm64)
You can set ALLOW_MISSING_DEPENDENCIES=true in your environment if this is intentional, but that may defer real problems until later in the build.
vendor/qcom/opensource/interfaces/wifi/supplicant/1.0/Android.mk: error: vendor.qti.hardware.wifi.supplicant-V1.0-java-static (JAVA_LIBRARIES android-arm64) missing android.hidl.base-V1.0-java-static (JAVA_LIBRARIES android-arm64)
You can set ALLOW_MISSING_DEPENDENCIES=true in your environment if this is intentional, but that may defer real problems until later in the build.
vendor/qcom/opensource/interfaces/wifi/supplicant/1.1/Android.mk: error: vendor.qti.hardware.wifi.supplicant-V1.1-java-static (JAVA_LIBRARIES android-arm64) missing android.hardware.wifi.supplicant-V1.0-java-static (JAVA_LIBRARIES android-arm64)
You can set ALLOW_MISSING_DEPENDENCIES=true in your environment if this is intentional, but that may defer real problems until later in the build.
vendor/qcom/opensource/interfaces/wifi/supplicant/1.1/Android.mk: error: vendor.qti.hardware.wifi.supplicant-V1.1-java-static (JAVA_LIBRARIES android-arm64) missing android.hidl.base-V1.0-java-static (JAVA_LIBRARIES android-arm64)
You can set ALLOW_MISSING_DEPENDENCIES=true in your environment if this is intentional, but that may defer real problems until later in the build.

Signed-off-by: David Viteri <davidteri91@gmail.com>