### PR TITLE
display: list all previous interface versions in interfaces.

### DIFF
--- a/display/config/1.3/Android.bp
+++ b/display/config/1.3/Android.bp
@@ -9,6 +9,7 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
         "vendor.display.config@1.2",
     ],
     gen_java: true,

--- a/display/config/1.4/Android.bp
+++ b/display/config/1.4/Android.bp
@@ -9,6 +9,8 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
+        "vendor.display.config@1.2",
         "vendor.display.config@1.3",
     ],
     gen_java: true,

--- a/display/config/1.5/Android.bp
+++ b/display/config/1.5/Android.bp
@@ -9,6 +9,9 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
+        "vendor.display.config@1.2",
+        "vendor.display.config@1.3",
         "vendor.display.config@1.4",
     ],
     gen_java: true,

--- a/display/config/1.6/Android.bp
+++ b/display/config/1.6/Android.bp
@@ -9,6 +9,10 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
+        "vendor.display.config@1.2",
+        "vendor.display.config@1.3",
+        "vendor.display.config@1.4",
         "vendor.display.config@1.5",
     ],
     gen_java: true,

--- a/display/config/1.7/Android.bp
+++ b/display/config/1.7/Android.bp
@@ -9,6 +9,11 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
+        "vendor.display.config@1.2",
+        "vendor.display.config@1.3",
+        "vendor.display.config@1.4",
+        "vendor.display.config@1.5",
         "vendor.display.config@1.6",
     ],
     gen_java: true,

--- a/display/config/1.8/Android.bp
+++ b/display/config/1.8/Android.bp
@@ -9,6 +9,12 @@ hidl_interface {
     interfaces: [
         "android.hidl.base@1.0",
         "vendor.display.config@1.0",
+        "vendor.display.config@1.1",
+        "vendor.display.config@1.2",
+        "vendor.display.config@1.3",
+        "vendor.display.config@1.4",
+        "vendor.display.config@1.5",
+        "vendor.display.config@1.6",
         "vendor.display.config@1.7",
     ],
     gen_java: true,


### PR DESCRIPTION
Shared library dependencies do not propagate since a library doesn't
necessarily need to link against all the libraries its dependencies link
against.
This however is the case with interface versions extending prior ones,
where generated C++ interface libraries have to access (static) members
of lower versions (eg. in interfaceChain()). For this reason, all
versions in the chain must be explicitly noted in the interfaces list.

This solves the following linker (for every combination of versions):
```
ld.lld: error: undefined symbol: vendor::display::config::V1_1::IDisplayConfig::descriptor
>>> referenced by DisplayConfigAll.cpp:76 (out/soong/.intermediates/vendor/qcom/opensource/interfaces/display/config/1.3/vendor.display.config@1.3_genc++/gen/vendor/display/config/1.3/DisplayConfigAll.cpp:76)
>>>               out/soong/.intermediates/vendor/qcom/opensource/interfaces/display/config/1.3/vendor.display.config@1.3/android_arm64_armv8-a_cortex-a53_vendor_static/obj/.intermediates/vendor/qcom/opensource/interfaces/display/config/1.3/vendor.display.config@1.3_genc++/gen/vendor/display/config/1.3/DisplayConfigAll.o:(vendor::display::config::V1_3::IDisplayConfig::interfaceChain(std::__1::function<void (android::hardware::hidl_vec<android::hardware::hidl_string> const&)>))
```