### PR TITLE
[7.1.r1] Android.bp: No absolute paths & remove os_pickup.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,37 +1,3 @@
 subdirs = [
     "*"
 ]
-hidl_package_root {
-    name: "vendor.qti.hardware.camera",
-    path: "vendor/qcom/opensource/interfaces/camera",
-}
-
-hidl_package_root {
-    name: "vendor.qti.hardware.cryptfshw",
-    path: "vendor/qcom/opensource/interfaces/cryptfshw",
-}
-
-hidl_package_root {
-    name: "vendor.qti.hardware.display",
-    path: "vendor/qcom/opensource/interfaces/display",
-}
-
-hidl_package_root {
-    name: "vendor.qti.hardware.wifi",
-    path: "vendor/qcom/opensource/interfaces/wifi",
-}
-
-hidl_package_root {
-    name: "vendor.display",
-    path: "vendor/qcom/opensource/interfaces/display",
-}
-
-hidl_package_root {
-    name: "vendor.qti.hardware.servicetracker",
-    path: "vendor/qcom/opensource/interfaces/servicetracker",
-}
-
-hidl_package_root {
-    name: "vendor.qti.hardware.bluetooth_audio",
-    path: "vendor/qcom/opensource/interfaces/bluetooth_audio",
-}

--- a/bluetooth_audio/Android.bp
+++ b/bluetooth_audio/Android.bp
@@ -1,0 +1,3 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.bluetooth_audio",
+}

--- a/camera/Android.bp
+++ b/camera/Android.bp
@@ -1,0 +1,3 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.camera",
+}

--- a/cryptfshw/Android.bp
+++ b/cryptfshw/Android.bp
@@ -1,0 +1,3 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.cryptfshw",
+}

--- a/display/Android.bp
+++ b/display/Android.bp
@@ -1,0 +1,6 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.display",
+}
+hidl_package_root {
+    name: "vendor.display",
+}

--- a/os_pickup.bp
+++ b/os_pickup.bp
@@ -1,5 +1,0 @@
-// Pick up Android.bp in next directory level
-
-optional_subdirs = [
-    "*",
-]

--- a/servicetracker/Android.bp
+++ b/servicetracker/Android.bp
@@ -1,0 +1,3 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.servicetracker",
+}

--- a/wifi/Android.bp
+++ b/wifi/Android.bp
@@ -1,0 +1,3 @@
+hidl_package_root {
+    name: "vendor.qti.hardware.wifi",
+}


### PR DESCRIPTION
For the `hidl_package_root` blueprint files, we do not need to specify absolute paths. The build system is smart enough to insert the current module path on Q, see [hidl_package_root.go](https://android.googlesource.com/platform/system/tools/hidl/+/refs/tags/android-10.0.0_r29/build/hidl_package_root.go#55)

`os_pickup.bp` is obsolete on Q, the build system will look for `Android.bp` files in subdirs anyway.
Another [commit to `local_manifests`](https://github.com/sonyxperiadev/local_manifests/pull/87) will remove it from there too.